### PR TITLE
Allow 'null' client roots

### DIFF
--- a/rbtools/clients/perforce.py
+++ b/rbtools/clients/perforce.py
@@ -233,15 +233,18 @@ class PerforceClient(SCMClient):
         if client_root is None:
             return None
 
-        norm_cwd = os.path.normcase(os.path.realpath(os.getcwd()) +
-                                    os.path.sep)
-        norm_client_root = os.path.normcase(os.path.realpath(client_root) +
-                                            os.path.sep)
+        # 'null' client root is a valid configuration on Windows clients
+        # don't enforce the repository directory check
+        if client_root.lower() != 'null':
+            norm_cwd = os.path.normcase(os.path.realpath(os.getcwd()) +
+                                        os.path.sep)
+            norm_client_root = os.path.normcase(os.path.realpath(client_root) +
+                                                os.path.sep)
 
-        # Don't accept the repository if the current directory is outside the
-        # root of the Perforce client.
-        if not norm_cwd.startswith(norm_client_root):
-            return None
+            # Don't accept the repository if the current directory is outside the
+            # root of the Perforce client.
+            if not norm_cwd.startswith(norm_client_root):
+                return None
 
         try:
             parts = repository_path.split(':')


### PR DESCRIPTION
Windows perforce clients are allowed to specify the client root as 'null'. If this is the case don't attempt to determine that the current directory is below the client root because the check will fail. With a 'null' client root all paths are below the client root.